### PR TITLE
feat(*): Add 'all' and 'any' utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,20 +46,21 @@ const userFlow = () => async function(dispatch, getState, take) {
 
 ```
 
-## Wait for action
+## Wait for an action
 
 ```.js
-await take('USER_INTERACTION');
+await take('USER_SELECTS_FLIGHT');
 ```
 
-## Or
+## Wait for any action
 
 ```.js
-await Promise.race([take("ACTION_A"), take("ACTION_B")]);
+await take.any(CREDIT_CARD_PAYMENT, OTHER_METHOD_PAYMENT);
 ```
 
-## And
+## Wait for multiple actions
 
 ```.js
-await Promise.all([take("ACTION_A"), take("ACTION_B")]);
+await take.all(CAPTCHA_CONFIRMATION, SMS_CONFIRMATION);
 ```
+

--- a/demo/actions.js
+++ b/demo/actions.js
@@ -30,12 +30,16 @@ export const USER_SELECTS_FLIGHT = "USER_SELECTS_FLIGHT";
 export const CREDIT_CARD_PAYMENT = "CREDIT_CARD_PAYMENT";
 export const OTHER_METHOD_PAYMENT = "OTHER_METHOD_PAYMENT";
 export const BOOKING_CANCELLATION = "BOOKING_CANCELLATION";
+export const CAPTCHA_CONFIRMATION = "CAPTCHA_CONFIRMATION";
+export const SMS_CONFIRMATION = "SMS_CONFIRMATION";
 
 export const userInteractions = {
   USER_SELECTS_FLIGHT,
   CREDIT_CARD_PAYMENT,
   OTHER_METHOD_PAYMENT,
   BOOKING_CANCELLATION,
+  CAPTCHA_CONFIRMATION,
+  SMS_CONFIRMATION
 };
 
 export const selectFlight = payload => ({
@@ -53,4 +57,12 @@ export const otherMethodsPayment = () => ({
 
 export const cancelBooking = () => ({
   type: userInteractions.BOOKING_CANCELLATION,
+});
+
+export const captchaConfirmation = () => ({
+  type: userInteractions.CAPTCHA_CONFIRMATION,
+});
+
+export const smsConfirmation = () => ({
+  type: userInteractions.SMS_CONFIRMATION,
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,27 @@
 function createAsyncFlowsMiddleware() {
-  
+
   const register = {};
 
-  const take = (action) => {
-    return new Promise(resolve => {
-      register[action] = [...(register[action] || []), resolve];
-    });
+  const take = (actionType) => {
+    if (typeof actionType === 'string') {
+      return new Promise(resolve => {
+        register[actionType] = [...(register[actionType] || []), resolve];
+      });
+    }
+    return Promise.reject(new Error(`Cannot take an ${typeof actionType}, string expected`))
   };
 
-  take.any = (...actions) => Promise.race(actions.map(take));
-  
-  take.all = (...actions) => Promise.all(actions.map(take))
+  take.any = (...actionTypes) => {
+    return Promise.race(actionTypes.map(take))
+  };
+
+  take.all = (...actionTypes) => Promise.all(actionTypes.map(take))
 
   return {
     take,
     asyncFlowsMiddleware: () => next => action => {
 
-      if(register[action.type]) {
+      if (register[action.type]) {
         register[action.type].forEach(resolve => resolve(action));
         register[action.type] = [];
       }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@ function createAsyncFlowsMiddleware() {
     });
   };
 
+  take.any = (...actions) => Promise.race(actions.map(take));
+  
+  take.all = (...actions) => Promise.all(actions.map(take))
+
   return {
     take,
     asyncFlowsMiddleware: () => next => action => {


### PR DESCRIPTION

* `take.all`: Which allows to wait for 'all' actions to be dispatched to continue flow execution
* `take.any`: Wait for any of the actions to be dispatched before continuing the execution.
* `.take` now returns a rejected promise when the handled value is not a string.




